### PR TITLE
Titlebar should have the ui-corner-all class, to maintain consistency with the jQuery UI Dialog

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -232,13 +232,13 @@ function install(el, opts) {
 	var lyr3, s;
 	if (opts.theme && full) {
 		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockPage ui-dialog ui-widget ui-corner-all" style="z-index:'+z+';display:none;position:fixed">' +
-				'<div class="ui-widget-header ui-dialog-titlebar blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
+				'<div class="ui-widget-header ui-dialog-titlebar ui-corner-all blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
 				'<div class="ui-widget-content ui-dialog-content"></div>' +
 			'</div>';
 	}
 	else if (opts.theme) {
 		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockElement ui-dialog ui-widget ui-corner-all" style="z-index:'+z+';display:none;position:absolute">' +
-				'<div class="ui-widget-header ui-dialog-titlebar blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
+				'<div class="ui-widget-header ui-dialog-titlebar ui-corner-all blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
 				'<div class="ui-widget-content ui-dialog-content"></div>' +
 			'</div>';
 	}


### PR DESCRIPTION
Was just upgrading my BlockUI to a newer version in a project, wanted to use the TR/UI classes, but I realised that BlockUI wasn't adding the ui-corner-all class to the titlebar when the theme option is on.  The jQuery UI dialog does apply this class to the titlebar, and for consistency's sake, I think BlockUI should as well.
