### PR TITLE
Allow for display of elements between screen and dialogue box, save onUnblock information

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -232,13 +232,13 @@ function install(el, opts) {
 	var lyr3, s;
 	if (opts.theme && full) {
 		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockPage ui-dialog ui-widget ui-corner-all" style="z-index:'+z+';display:none;position:fixed">' +
-				'<div class="ui-widget-header ui-dialog-titlebar blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
+				'<div class="ui-widget-header ui-dialog-titlebar ui-corner-all blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
 				'<div class="ui-widget-content ui-dialog-content"></div>' +
 			'</div>';
 	}
 	else if (opts.theme) {
 		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockElement ui-dialog ui-widget ui-corner-all" style="z-index:'+z+';display:none;position:absolute">' +
-				'<div class="ui-widget-header ui-dialog-titlebar blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
+				'<div class="ui-widget-header ui-dialog-titlebar ui-corner-all blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
 				'<div class="ui-widget-content ui-dialog-content"></div>' +
 			'</div>';
 	}

--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -217,6 +217,7 @@ function install(el, opts) {
 			data.parent.removeChild(node);
 	}
 
+	$(el).data('blockUI.onUnblock', opts.onUnblock);
 	var z = opts.baseZ;
 
 	// blockUI uses 3 layers for blocking, for simplicity they are all used on every platform;
@@ -231,22 +232,22 @@ function install(el, opts) {
 	
 	var lyr3, s;
 	if (opts.theme && full) {
-		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockPage ui-dialog ui-widget ui-corner-all" style="z-index:'+z+';display:none;position:fixed">' +
+		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockPage ui-dialog ui-widget ui-corner-all" style="z-index:'+(z+10)+';display:none;position:fixed">' +
 				'<div class="ui-widget-header ui-dialog-titlebar ui-corner-all blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
 				'<div class="ui-widget-content ui-dialog-content"></div>' +
 			'</div>';
 	}
 	else if (opts.theme) {
-		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockElement ui-dialog ui-widget ui-corner-all" style="z-index:'+z+';display:none;position:absolute">' +
+		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockElement ui-dialog ui-widget ui-corner-all" style="z-index:'+(z+10)+';display:none;position:absolute">' +
 				'<div class="ui-widget-header ui-dialog-titlebar ui-corner-all blockTitle">'+(opts.title || '&nbsp;')+'</div>' +
 				'<div class="ui-widget-content ui-dialog-content"></div>' +
 			'</div>';
 	}
 	else if (full) {
-		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockPage" style="z-index:'+z+';display:none;position:fixed"></div>';
-	}			
+		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockPage" style="z-index:'+(z+10)+';display:none;position:fixed"></div>';
+	}			 
 	else {
-		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockElement" style="z-index:'+z+';display:none;position:absolute"></div>';
+		s = '<div class="blockUI ' + opts.blockMsgClass + ' blockElement" style="z-index:'+(z+10)+';display:none;position:absolute"></div>';
 	}
 	lyr3 = $(s);
 
@@ -383,7 +384,12 @@ function remove(el, opts) {
 	}
 	opts = $.extend({}, $.blockUI.defaults, opts || {});
 	bind(0, el, opts); // unbind events
-	
+
+	if (opts.onUnblock === null) {
+		opts.onUnblock = $el.data('blockUI.onUnblock');
+		$el.removeData('blockUI.onUnblock');
+	}
+
 	var els;
 	if (full) // crazy selector to handle odd field errors in ie6/7
 		els = $('body').children().filter('.blockUI').add('body > .blockUI');

--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -1,6 +1,6 @@
 ﻿/*!
  * jQuery blockUI plugin
- * Version 2.35 (23-SEP-2010)
+ * Version 2.36 (16-NOV-2010)
  * @requires jQuery v1.2.3 or later
  *
  * Examples at: http://malsup.com/jquery/block/
@@ -450,8 +450,8 @@ function handler(e) {
 	if (e.keyCode && e.keyCode == 9) {
 		if (pageBlock && e.data.constrainTabKey) {
 			var els = pageBlockEls;
-			var fwd = !e.shiftKey && e.target == els[els.length-1];
-			var back = e.shiftKey && e.target == els[0];
+			var fwd = !e.shiftKey && e.target === els[els.length-1];
+			var back = e.shiftKey && e.target === els[0];
 			if (fwd || back) {
 				setTimeout(function(){focus(back)},10);
 				return false;


### PR DESCRIPTION
Adding 10 to the baseZ allows you to unblock specific elements that are blocked by the overlay but still keep the dialog box over them.

The second part is a cleanup for the new version of the patch created to allow you to define the onUnblock section and be able to call it using just an unBlockUI() without having to re-define it.
