### PR TITLE
Remove BOM (Byte order mark) from beginning of file as it makes certain JavaScript compressors die.

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -1,4 +1,4 @@
-﻿/*!
+/*!
  * jQuery blockUI plugin
  * Version 2.42 (11-MAY-2012)
  * @requires jQuery v1.2.3 or later


### PR DESCRIPTION
Particularly UglifyJS.
