### PR TITLE
Fix for an issue with spacebar keyup event not being blocked.

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -503,7 +503,7 @@
 				return;
 
 			// bind anchors and inputs for mouse and key events
-			var events = 'mousedown mouseup keydown keypress touchstart touchend touchmove';
+			var events = 'mousedown mouseup keydown keypress keyup touchstart touchend touchmove';
 			if (b)
 				$(document).bind(events, opts, handler);
 			else


### PR DESCRIPTION
Our team had an issue wherein spacebar events were still able to modify the value of elements blocked by blockUI.  Adding 'keyup' to list of events to be blocked solved our issue.
