### PR TITLE
pageBlockEls selector

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -185,6 +185,9 @@
 			// if true, focus will be placed in the first available input field when
 			// page blocking
 			focusInput: true,
+            
+            // elements that can receive focus
+            focusableElements: ':input:enabled:visible',
 
 			// suppresses the use of overlay styles on FF/Linux (due to performance issues with opacity)
 			// no longer needed in 2012
@@ -405,7 +408,7 @@
 
 			if (full) {
 				pageBlock = lyr3[0];
-				pageBlockEls = $(':input:enabled:visible',pageBlock);
+				pageBlockEls = $(opts.focusableElements,pageBlock);
 				if (opts.focusInput)
 					setTimeout(focus, 20);
 			}


### PR DESCRIPTION
Hi,

In my current accessibility project I had a task that not only the input fields should get focused on the overlay, but also the links. Sadly this is hard-coded into blockui plugin, so I made it an option. So now I can edit it e.g. like this: ':input:enabled:visible,a:visible'.

I hope you'll like it, besides this I really like your plug-in, keep up the great work!

Péter
