### PR TITLE
Removing the word "retarded" from the comments

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -22,7 +22,7 @@
 		var noOp = $.noop || function() {};
 
 		// this bit is to ensure we don't call setExpression when we shouldn't (with extra muscle to handle
-		// retarded userAgent strings on Vista)
+		// confusing userAgent strings on Vista)
 		var msie = /MSIE/.test(navigator.userAgent);
 		var ie6  = /MSIE 6.0/.test(navigator.userAgent) && ! /MSIE 8.0/.test(navigator.userAgent);
 		var mode = document.documentMode || 0;


### PR DESCRIPTION
Aw, you know, it is kind of offensive is all.  The unnecessary kind of offensive that doesn't need to be enshrined in code.
