### PR TITLE
Fix warning by Google Closure compiler

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -1,7 +1,7 @@
 /*!
  * jQuery blockUI plugin
  * Version 2.64.0-2013.07.18
- * @requires jQuery v1.7 or later
+ * requires jQuery v1.7 or later
  *
  * Examples at: http://malsup.com/jquery/block/
  * Copyright (c) 2007-2013 M. Alsup


### PR DESCRIPTION
Having "@requires" in that comment in the header will yield a warning by the Google Closure compiler. Either removing the "@" or replacing "/_!" by "/_*" in the header should fix the warning.
