### PR TITLE
Pass event object to onOverlayClick()

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -576,7 +576,7 @@
 			var opts = e.data;
 			var target = $(e.target);
 			if (target.hasClass('blockOverlay') && opts.onOverlayClick)
-				opts.onOverlayClick();
+				opts.onOverlayClick(e);
 
 			// allow events within the message content
 			if (target.parents('div.' + opts.blockMsgClass).length > 0)


### PR DESCRIPTION
Pass the event object down to the overlay click handler so it is possible to determine which mouse button was clicked.
