### PR TITLE
Uniformize context for onBlock callback

### DIFF
--- a/jquery.blockUI.js
+++ b/jquery.blockUI.js
@@ -426,7 +426,7 @@
 				if (msg)
 					lyr3.show();
 				if (opts.onBlock)
-					opts.onBlock();
+					opts.onBlock.bind(lyr3)();
 			}
 
 			// bind key and mouse events


### PR DESCRIPTION
- when opts.fadeIn > 0, onBlock callback context is lyr3
- when opts.fadeIn == 0, onBlock callback context is this

--> with this patch, when opts.fadeIn == 0, onBlock callback context is lyr3
