### PR TITLE
Description in bower.json should be no longer than 140 chars

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "blockUI",
   "title": "BlockUI",
-  "description": "Simulate synchronous ajax by blocking - not locking - the UI. This plugin lets you block user interaction with the page or with a specific element on the page. Also great at displaying modal dialogs.",
+  "description": "This plugin lets you block user interaction with the page or with a specific element on the page. Also great at displaying modal dialogs.",
   "keywords": [
     "block",
     "overlay",


### PR DESCRIPTION
ReSharper gives the following error:

> JSON validation failed: String length must be not greater than 140