### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "blockUI",
   "title": "BlockUI",
-  "description": "Simulate synchronous ajax by blocking - not locking - the UI. This plugin lets you block user interaction with the page or with a specific element on the page. Also great at displaying modal dialogs.",
+  "description": "Simulate synchronous ajax by blocking - not locking - the UI.",
   "keywords": [
     "block",
     "overlay",


### PR DESCRIPTION
bower blockUI#*                                      invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes
bower blockUI#*                                      invalid-meta The "description" is too long, the limit is 140 characters